### PR TITLE
build: add initial project dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django>=5.1.7
+django-environ>=0.11.2
+django-allauth>=0.57.0
+django-crispy-forms>=2.1
+stripe>=17.7.0


### PR DESCRIPTION
This commit introduces the initial set of dependencies required for the project, including Django, django-environ, django-allauth, django-crispy-forms, and stripe. These libraries are essential for setting up the project's core functionality.