### PR TITLE
chore: remove version constraints from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django>=5.1.7
-django-environ>=0.11.2
-django-allauth>=0.57.0
-django-crispy-forms>=2.1
-stripe>=17.7.0
+Django
+django-environ
+django-allauth
+django-crispy-forms
+stripe


### PR DESCRIPTION
The version constraints were removed to simplify dependency management and avoid potential conflicts during installation. This change allows the latest compatible versions of the packages to be installed automatically.