### PR TITLE
build: add gunicorn to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ django-environ
 django-allauth
 django-crispy-forms
 stripe
+gunicorn


### PR DESCRIPTION
Add gunicorn as a dependency to requirements.txt to support deploying the Django application with a production-ready WSGI server